### PR TITLE
Implement chat frontend and backend

### DIFF
--- a/backend/agent.js
+++ b/backend/agent.js
@@ -20,11 +20,6 @@ Usá las herramientas disponibles para:
 Respondé de forma clara y breve.
 `.trim();
 
-const ollamaLLM = new Ollama({
-    model: "qwen3:1.7b",
-    temperature: 0.75,
-    timeout: 2 * 60 * 1000,
-});
 
 const buscarPorNombreTool = tool({
     name: "buscarPorNombre",
@@ -79,11 +74,23 @@ const listarEstudiantesTool = tool({
     },
 });
 
-const elAgente = agent({
-    tools: [buscarPorNombreTool, buscarPorApellidoTool, agregarEstudianteTool, listarEstudiantesTool],
-    llm: ollamaLLM,
-    verbose: DEBUG,
-    systemPrompt: systemPrompt,
-});
+const TOOLS = [
+    buscarPorNombreTool,
+    buscarPorApellidoTool,
+    agregarEstudianteTool,
+    listarEstudiantesTool,
+];
 
-export { elAgente };
+function createAgent({ model = "qwen3:1.7b", temperature = 0.75 } = {}) {
+    const llm = new Ollama({ model, temperature, timeout: 2 * 60 * 1000 });
+    return agent({
+        tools: TOOLS,
+        llm,
+        verbose: DEBUG,
+        systemPrompt,
+    });
+}
+
+const elAgente = createAgent();
+
+export { createAgent, elAgente };

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,9 +1,9 @@
 import express from 'express';
 import cors from 'cors';
 import morgan from 'morgan';
-import { elAgente } from './agent.js';
+import { createAgent } from './agent.js';
 
-const app = express();
+export const app = express();
 app.use(cors());
 app.use(express.json());
 app.use(morgan('dev'));
@@ -12,12 +12,13 @@ app.use(express.static(new URL('../public', import.meta.url).pathname));
 
 
 app.post('/api/chat', async (req, res) => {
-  const { prompt } = req.body;
+  const { prompt, model, temperature } = req.body;
   if (!prompt) {
     return res.status(400).json({ error: 'Prompt requerido' });
   }
+  const agente = createAgent({ model, temperature });
   try {
-    const respuesta = await elAgente.run(prompt);
+    const respuesta = await agente.run(prompt);
     res.json({ result: respuesta.data.result });
   } catch (err) {
     console.error('Error al procesar el mensaje', err);
@@ -25,7 +26,11 @@ app.post('/api/chat', async (req, res) => {
   }
 });
 
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Servidor escuchando en http://localhost:${PORT}`);
-});
+if (process.env.NODE_ENV !== 'test') {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`Servidor escuchando en http://localhost:${PORT}`);
+  });
+}
+
+export default app;

--- a/backend/tests/chat.test.js
+++ b/backend/tests/chat.test.js
@@ -1,0 +1,28 @@
+import request from 'supertest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { app } from '../server.js';
+import http from 'http';
+
+let server;
+
+beforeAll(async () => {
+  server = http.createServer(app);
+  await new Promise(res => server.listen(0, res));
+});
+
+afterAll(async () => {
+  await new Promise(res => server.close(res));
+});
+
+describe('POST /api/chat', () => {
+  it('should return 400 if no prompt', async () => {
+    const res = await request(server).post('/api/chat').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('should return result with prompt', async () => {
+    const res = await request(server).post('/api/chat').send({ prompt: 'hola' });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('result');
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
-    "axios": "^1.2.0"
+    "axios": "^1.2.0",
+    "react-markdown": "^9.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,14 +1,20 @@
-import { useState, useRef, useEffect } from 'react';
-import axios from 'axios';
+import { useState, useEffect } from 'react';
+import Chat from './Chat.jsx';
+import { sendChat } from './api.js';
 
-function App() {
-  const [messages, setMessages] = useState([]);
+export default function App() {
+  const [messages, setMessages] = useState(() => {
+    const saved = localStorage.getItem('chatHistory');
+    return saved ? JSON.parse(saved) : [];
+  });
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
-  const endRef = useRef(null);
+  const [model, setModel] = useState('qwen3:1.7b');
+  const [temperature, setTemperature] = useState(0.75);
+  const [tool, setTool] = useState('estudiantes');
 
   useEffect(() => {
-    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+    localStorage.setItem('chatHistory', JSON.stringify(messages));
   }, [messages]);
 
   const sendMessage = async (e) => {
@@ -19,8 +25,7 @@ function App() {
     setInput('');
     setLoading(true);
     try {
-      const res = await axios.post('/api/chat', { prompt: userMsg.text });
-      const data = res.data;
+      const data = await sendChat(userMsg.text, model, temperature, tool);
       const botMsg = { role: 'bot', text: data.result || data.error };
       setMessages(m => [...m, botMsg]);
     } catch (err) {
@@ -32,13 +37,7 @@ function App() {
 
   return (
     <div className="chat-container">
-      <div className="messages">
-        {messages.map((m, i) => (
-          <div key={i} className={m.role}>{m.text}</div>
-        ))}
-        {loading && <div className="loading">Pensando...</div>}
-        <div ref={endRef}></div>
-      </div>
+      <Chat messages={messages} loading={loading} />
       <form className="input-area" onSubmit={sendMessage}>
         <input
           type="text"
@@ -46,10 +45,24 @@ function App() {
           onChange={e => setInput(e.target.value)}
           placeholder="Escribí tu pregunta"
         />
+        <select value={tool} onChange={e => setTool(e.target.value)}>
+          <option value="estudiantes">Estudiantes</option>
+        </select>
+        <select value={model} onChange={e => setModel(e.target.value)}>
+          <option value="qwen3:1.7b">qwen3:1.7b</option>
+          <option value="llama2:7b">llama2:7b</option>
+        </select>
+        <input
+          type="number"
+          step="0.01"
+          min="0"
+          max="1"
+          value={temperature}
+          onChange={e => setTemperature(parseFloat(e.target.value))}
+          style={{ width: '4rem' }}
+        />
         <button type="submit" disabled={loading}>Enviar</button>
       </form>
     </div>
   );
 }
-
-export default App;

--- a/frontend/src/Chat.jsx
+++ b/frontend/src/Chat.jsx
@@ -1,0 +1,23 @@
+import { useRef, useEffect } from 'react';
+import ReactMarkdown from 'react-markdown';
+
+export default function Chat({ messages, loading }) {
+  const endRef = useRef(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, loading]);
+
+  return (
+    <div className="messages">
+      {messages.map((m, i) => (
+        <div key={i} className={`message ${m.role}`}> 
+          {m.role === 'bot' && <span className="avatar">🤖</span>}
+          <ReactMarkdown>{m.text}</ReactMarkdown>
+        </div>
+      ))}
+      {loading && <div className="loading">Pensando...</div>}
+      <div ref={endRef}></div>
+    </div>
+  );
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export async function sendChat(prompt, model, temperature, tool) {
+  const res = await axios.post('/api/chat', { prompt, model, temperature, tool });
+  return res.data;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,14 +26,22 @@ body {
   overflow-y: auto;
 }
 
-.messages .user {
-  text-align: right;
+.message {
   margin: 5px 0;
+  display: flex;
+  gap: 4px;
 }
 
-.messages .bot {
-  text-align: left;
-  margin: 5px 0;
+.message.user {
+  justify-content: flex-end;
+}
+
+.message.bot {
+  justify-content: flex-start;
+}
+
+.avatar {
+  font-size: 1.2rem;
 }
 
 .loading {
@@ -45,6 +53,7 @@ body {
   display: flex;
   padding: 10px;
   border-top: 1px solid #ddd;
+  gap: 8px;
 }
 
 .input-area input {
@@ -55,7 +64,10 @@ body {
 
 .input-area button {
   padding: 8px 16px;
-  margin-left: 8px;
+}
+
+.input-area select {
+  padding: 8px;
 }
 
 @media (max-width: 600px) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node backend/main.js",
-    "server": "node backend/server.js"
+    "server": "node backend/server.js",
+    "test": "vitest run"
   },
   "author": "",
   "license": "ISC",
@@ -18,6 +19,10 @@
     "express": "^4.18.3",
     "cors": "^2.8.5",
     "morgan": "^1.10.0"
+  },
+  "devDependencies": {
+    "supertest": "^6.3.3",
+    "vitest": "^1.1.0"
   },
   "type": "module"
 }

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,5 @@
+export default {
+  test: {
+    environment: 'node',
+  },
+};


### PR DESCRIPTION
## Summary
- add dynamic LLM options with `createAgent`
- export Express `app` and support model/temperature in endpoint
- create React chat with history, markdown and selectors
- style chat UI and add helper API functions
- add basic backend tests with Vitest

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587b06f78c833184ec0469ca31b922