### PR TITLE
Simplify project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
+# Proyecto de ejemplo
 
+Este repositorio incluye un backend en `backend/` y una interfaz web en `frontend/`.
+
+## Instalación
+
+Ejecuta un único comando para instalar todas las dependencias:
+
+```bash
+npm install
+```
+
+El script `postinstall` instalará automáticamente los paquetes del frontend.
+
+## Ejecución
+
+Para levantar el servidor y la aplicación web en paralelo, usa:
+
+```bash
+npm run start:dev
+```
+
+Se abrirá la página en tu navegador y el backend quedará disponible en `http://localhost:3000`.
+
+Si solo deseas utilizar el asistente por consola puedes ejecutar:
+
+```bash
+npm start
+```
+
+### Solución de problemas
+
+En algunos entornos Windows puede aparecer un mensaje similar a:
+
+```
+npm warn cleanup [...]
+npm ERR! EPERM: operation not permitted, rmdir '...\\node_modules'
+```
+
+Esto suele indicar que la carpeta `frontend/node_modules` está en uso. Cierra
+cualquier proceso que esté ejecutando la aplicación, elimina dicha carpeta y
+vuelve a ejecutar `npm install`.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "start": "node backend/main.js",
     "server": "node backend/server.js",
+    "start:dev": "concurrently \"npm run server\" \"npm start --prefix frontend\"",
+    "postinstall": "npm install --prefix frontend",
     "test": "vitest run"
   },
   "author": "",
@@ -22,7 +24,8 @@
   },
   "devDependencies": {
     "supertest": "^6.3.3",
-    "vitest": "^1.1.0"
+    "vitest": "^1.1.0",
+    "concurrently": "^8.2.0"
   },
   "type": "module"
 }


### PR DESCRIPTION
## Summary
- document how to install and run the project
- add `start:dev` and `postinstall` scripts
- include `concurrently` to run backend & frontend in parallel
- add troubleshooting steps for Windows

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:11434)*

------
https://chatgpt.com/codex/tasks/task_e_685880ca536c8331877973412658b02f