### PR TITLE
Fix dev server ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Para levantar el servidor y la aplicación web en paralelo, usa:
 npm run start:dev
 ```
 
-Se abrirá la página en tu navegador y el backend quedará disponible en `http://localhost:3000`.
+El comando levantará el frontend en `http://localhost:3000` y el backend en `http://localhost:3001` automáticamente, sin necesidad de cambiar puertos manualmente.
 
 Si solo deseas utilizar el asistente por consola puedes ejecutar:
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,5 +14,6 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
-  }
+  },
+  "proxy": "http://localhost:3001"
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node backend/main.js",
     "server": "node backend/server.js",
-    "start:dev": "concurrently \"npm run server\" \"npm start --prefix frontend\"",
+    "start:dev": "concurrently \"PORT=3001 npm run server\" \"PORT=3000 npm start --prefix frontend\"",
     "test": "vitest run"
   },
   "author": "",


### PR DESCRIPTION
## Summary
- automatically set backend and frontend ports
- proxy frontend requests to backend
- update instructions

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:11434)*

------
https://chatgpt.com/codex/tasks/task_e_68588f8c5ff0833197749b51a356ed48