### PR TITLE
Fix dev port script on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Para levantar el servidor y la aplicación web en paralelo, usa:
 npm run start:dev
 ```
 
-Se abrirá la página en tu navegador y el backend quedará disponible en `http://localhost:3000`.
+El comando levantará el frontend en `http://localhost:3000` y el backend en `http://localhost:3001` automáticamente. Gracias a `cross-env` no es necesario cambiar puertos manualmente, incluso en Windows.
 
 Si solo deseas utilizar el asistente por consola puedes ejecutar:
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,5 +14,6 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
-  }
+  },
+  "proxy": "http://localhost:3001"
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node backend/main.js",
     "server": "node backend/server.js",
-    "start:dev": "concurrently \"npm run server\" \"npm start --prefix frontend\"",
+    "start:dev": "concurrently \"cross-env PORT=3001 npm run server\" \"cross-env PORT=3000 npm start --prefix frontend\"",
     "test": "vitest run"
   },
   "author": "",
@@ -24,7 +24,8 @@
   "devDependencies": {
     "supertest": "^6.3.3",
     "vitest": "^1.1.0",
-    "concurrently": "^8.2.0"
+    "concurrently": "^8.2.0",
+    "cross-env": "^7.0.3"
   },
   "type": "module"
 }


### PR DESCRIPTION
## Summary
- make the dev script cross-platform with `cross-env`
- mention automatic port setup in the README

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:11434)*

------
https://chatgpt.com/codex/tasks/task_e_68588f8c5ff0833197749b51a356ed48