### PR TITLE
Add one-command dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,23 @@ Este repositorio incluye un backend en `backend/` y una interfaz web en `fronten
 
 ## Instalación
 
-Ejecuta un único comando para instalar todas las dependencias:
+Con un único comando podrás instalar todas las dependencias y lanzar el entorno de desarrollo:
 
 ```bash
-npm install
+npm run dev
 ```
 
-Si necesitas reinstalar las dependencias del frontend puedes ejecutar:
+Tras ejecutar `npm run dev` se instalarán las dependencias del proyecto principal y del frontend, iniciando después ambos servidores.
+
+El frontend quedará disponible en `http://localhost:3000` y el backend en `http://localhost:3001` automáticamente. Gracias a `cross-env` no es necesario cambiar puertos manualmente, incluso en Windows.
+
+Si en algún momento necesitas reinstalar las dependencias sin arrancar el proyecto puedes utilizar:
 
 ```bash
-npm install --prefix frontend
+npm run setup
 ```
 
-## Ejecución
-
-Para levantar el servidor y la aplicación web en paralelo, usa:
-
-```bash
-npm run start:dev
-```
-
-El comando levantará el frontend en `http://localhost:3000` y el backend en `http://localhost:3001` automáticamente. Gracias a `cross-env` no es necesario cambiar puertos manualmente, incluso en Windows.
-
-Si solo deseas utilizar el asistente por consola puedes ejecutar:
+Y si solo deseas utilizar el asistente por consola ejecuta:
 
 ```bash
 npm start

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "concurrently": "^8.2.0",
+        "cross-env": "^7.0.3",
         "supertest": "^6.3.3",
         "vitest": "^1.1.0"
       }
@@ -1503,6 +1504,25 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "start": "node backend/main.js",
     "server": "node backend/server.js",
-     "start:dev": "concurrently \"cross-env PORT=3001 npm run server\" \"cross-env PORT=3000 npm start --prefix frontend\"",
+    "start:dev": "concurrently \"cross-env PORT=3001 npm run server\" \"cross-env PORT=3000 npm start --prefix frontend\"",
+    "setup": "npm install && npm install --prefix frontend",
+    "dev": "npm run setup && npm run start:dev",
     "test": "vitest run"
   },
   "author": "",


### PR DESCRIPTION
## Summary
- allow running `npm run dev` to install everything and start backend/frontend
- document the new workflow in README

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:11434)*

------
https://chatgpt.com/codex/tasks/task_e_6858930eb30c8331ae1b110402568d36