### PR TITLE
Disable verbose chat logs

### DIFF
--- a/backend/agent.js
+++ b/backend/agent.js
@@ -3,7 +3,7 @@ import { Ollama } from "@llamaindex/ollama";
 import { z } from "zod";
 import { Estudiantes } from "./lib/estudiantes.js";
 
-const DEBUG = true;
+const DEBUG = false;
 
 const estudiantes = new Estudiantes();
 estudiantes.cargarEstudiantesDesdeJson();

--- a/backend/lib/cli-chat.js
+++ b/backend/lib/cli-chat.js
@@ -4,8 +4,12 @@ function imprimirMensaje(mensaje) {
   console.log(mensaje);
 }
 
+function cleanResult(text) {
+  return text.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+}
+
 function formatResponse(response){
-  return `📝 Respuesta:\n${response.data.result}`;
+  return `📝 Respuesta:\n${cleanResult(response.data.result)}`;
 }
 
 const mensajeBienvenidaDefault = `

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,10 @@ import cors from 'cors';
 import morgan from 'morgan';
 import { createAgent } from './agent.js';
 
+function cleanResult(text) {
+  return text.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+}
+
 export const app = express();
 app.use(cors());
 app.use(express.json());
@@ -19,7 +23,7 @@ app.post('/api/chat', async (req, res) => {
   const agente = createAgent({ model, temperature });
   try {
     const respuesta = await agente.run(prompt);
-    res.json({ result: respuesta.data.result });
+    res.json({ result: cleanResult(respuesta.data.result) });
   } catch (err) {
     console.error('Error al procesar el mensaje', err);
     res.status(500).json({ error: 'No se pudo procesar el mensaje' });


### PR DESCRIPTION
## Summary
- avoid printing chain-of-thought output by default
- clean any remaining <think> tags from CLI and server responses

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:11434)*

------
https://chatgpt.com/codex/tasks/task_e_68594ccf6594833184f17424df9fbaad